### PR TITLE
add args for specifying index name and meta_index_name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,21 @@ For information on running mongo-connector with elastic, please see https://gith
 
 .. note:: Please note that before mongo-connector version 2.2.2, the elastic doc manager was packaged with mongo-connector and only supported Elastic 1.x.
 
+Configuration
+~~~~~~~~~~~~
+Example config JSON body for this DocManager::
+
+  "docManagers": [
+    {
+      "docManager": "elastic2_doc_manager",
+      "targetURL": "localhost:9200",
+      "args": {
+        "meta_index_name": "vendop_v5_meta",
+        "index": "vendop_v5"
+      }
+    }
+  ]
+
 Running the tests
 -----------------
 Requirements

--- a/mongo_connector/doc_managers/elastic2_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic2_doc_manager.py
@@ -59,13 +59,14 @@ class DocManager(DocManagerBase):
         self.elastic = Elasticsearch(
             hosts=[url], **kwargs.get('clientOptions', {}))
         self.auto_commit_interval = auto_commit_interval
-        self.meta_index_name = meta_index_name
+        self.meta_index_name = kwargs.get('meta_index_name', meta_index_name)
         self.meta_type = meta_type
         self.unique_key = unique_key
         self.chunk_size = chunk_size
         if self.auto_commit_interval not in [None, 0]:
             self.run_auto_commit()
         self._formatter = DefaultDocumentFormatter()
+        self._index = kwargs.get('index', '')
 
         self.has_attachment_mapping = False
         self.attachment_field = attachment_field
@@ -73,6 +74,8 @@ class DocManager(DocManagerBase):
     def _index_and_mapping(self, namespace):
         """Helper method for getting the index and type from a namespace."""
         index, doc_type = namespace.split('.', 1)
+        if not self._index == '':
+            index = self._index
         return index.lower(), doc_type
 
     def stop(self):


### PR DESCRIPTION
specifying index and meta_index name in the JSON config so you can
build an index that doesn't name match to mongo database. Useful for
building an index on the side before changing the alias for the
application

config params example:

  "docManagers": [
    {
      "docManager": "elastic2_doc_manager",
      "targetURL": "localhost:9200",
      "args": {
        "meta_index_name": "name of meta index name",
        "index": "my new index"
      }
    }
  ]
