### PR TITLE
Support parent-child relationship 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.egg-info/
 *~
 .DS_Store
 /test/data

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ python:
 
 install:
   - pip install mongo-orchestration
-  - sudo curl -L -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.2.0/elasticsearch-2.2.0.tar.gz
-  - tar -xvf elasticsearch-2.2.0.tar.gz
-  - cd elasticsearch-2.2.0
+  - sudo curl -L -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.1/elasticsearch-2.3.1.tar.gz
+  - tar -xvf elasticsearch-2.3.1.tar.gz
+  - cd elasticsearch-2.3.1
   - echo 'y' |  bin/plugin install mapper-attachments
 
 before_script:

--- a/README.rst
+++ b/README.rst
@@ -32,9 +32,9 @@ Running the tests
 Requirements
 ~~~~~~~~~~~~
 
-1. Copy of the Elastic 2.x Document Manager Github repository
+1. Copy of the Elastic 2.x Document Manager GitHub repository
 
-  The tests are not included in the package from PyPI and can only be acquired by cloning this repository on Github::
+  The tests are not included in the package from PyPI and can only be acquired by cloning this repository on GitHub::
 
       git clone https://github.com/mongodb-labs/elastic2-doc-manager
 

--- a/mongo_connector/doc_managers/elastic2_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic2_doc_manager.py
@@ -63,6 +63,7 @@ class DocManager(DocManagerBase):
         self.meta_type = meta_type
         self.unique_key = unique_key
         self.chunk_size = chunk_size
+        self.routing = kwargs.get('routing', {})
         if self.auto_commit_interval not in [None, 0]:
             self.run_auto_commit()
         self._formatter = DefaultDocumentFormatter()
@@ -74,6 +75,31 @@ class DocManager(DocManagerBase):
         """Helper method for getting the index and type from a namespace."""
         index, doc_type = namespace.split('.', 1)
         return index.lower(), doc_type
+
+    def _get_parent_id(self, doc_type, doc):
+        """Get parent ID from doc"""
+        if doc_type in self.routing:
+            parent_field = self.routing[doc_type].get('parentField')
+            if not parent_field:
+                return None
+            parent_id = doc.get(parent_field)
+            return self._formatter.transform_value(parent_id)
+
+    def _search_doc_by_id(self, index, doc_type, doc_id):
+        """Search document in Elasticsearch by _id"""
+        result = self.elastic.search(index=index, doc_type=doc_type,
+                                     body={
+                                         'query': {
+                                             'ids': {
+                                                 'type': doc_type,
+                                                 'values': [u(doc_id)]
+                                             }
+                                         }
+                                     })
+        if result['hits']['total'] == 1:
+            return result['hits']['hits'][0]
+        else:
+            return None
 
     def stop(self):
         """Stop the auto-commit thread."""
@@ -131,8 +157,20 @@ class DocManager(DocManagerBase):
         """
         self.commit()
         index, doc_type = self._index_and_mapping(namespace)
-        document = self.elastic.get(index=index, doc_type=doc_type,
-                                    id=u(document_id))
+
+        if doc_type in self.routing and 'parentField' in self.routing[doc_type]:
+            # We can't use get() here and have to do a full search instead.
+            # This is due to the fact that Elasticsearch needs the parent ID to
+            # know where to route the get request. We might not have the parent
+            # ID available in our update request though.
+            document = self._search_doc_by_id(index, doc_type, document_id)
+            if document is None:
+                LOG.error('Could not find document with ID "%s" in Elasticsearch to apply update', u(document_id))
+                return None
+        else:
+            document = self.elastic.get(index=index, doc_type=doc_type,
+                                        id=u(document_id))
+
         updated = self.apply_update(document['_source'], update_spec)
         # _id is immutable in MongoDB, so won't have changed in update
         updated['_id'] = document['_id']
@@ -150,10 +188,18 @@ class DocManager(DocManagerBase):
             "ns": namespace,
             "_ts": timestamp
         }
+
+        parent_id = self._get_parent_id(doc_type, doc)
         # Index the source document, using lowercase namespace as index name.
-        self.elastic.index(index=index, doc_type=doc_type,
-                           body=self._formatter.format_document(doc), id=doc_id,
-                           refresh=(self.auto_commit_interval == 0))
+        if parent_id is None:
+            self.elastic.index(index=index, doc_type=doc_type,
+                               body=self._formatter.format_document(doc), id=doc_id,
+                               refresh=(self.auto_commit_interval == 0))
+        else:
+            self.elastic.index(index=index, doc_type=doc_type,
+                               body=self._formatter.format_document(doc), id=doc_id,
+                               parent=parent_id, refresh=(self.auto_commit_interval == 0))
+
         # Index document metadata with original namespace (mixed upper/lower).
         self.elastic.index(index=self.meta_index_name, doc_type=self.meta_type,
                            body=bson.json_util.dumps(metadata), id=doc_id,
@@ -185,6 +231,11 @@ class DocManager(DocManagerBase):
                         "_ts": timestamp
                     }
                 }
+
+                parent_id = self._get_parent_id(doc_type, doc)
+                if parent_id is not None:
+                    document_action["_parent"] = parent_id
+
                 yield document_action
                 yield document_meta
             if doc is None:
@@ -238,9 +289,16 @@ class DocManager(DocManagerBase):
         doc = self._formatter.format_document(doc)
         doc[self.attachment_field] = base64.b64encode(f.read()).decode()
 
-        self.elastic.index(index=index, doc_type=doc_type,
-                           body=doc, id=doc_id,
-                           refresh=(self.auto_commit_interval == 0))
+        parent_id = self._get_parent_id(doc_type, doc)
+        if parent_id is None:
+            self.elastic.index(index=index, doc_type=doc_type,
+                               body=doc, id=doc_id,
+                               refresh=(self.auto_commit_interval == 0))
+        else:
+            self.elastic.index(index=index, doc_type=doc_type,
+                               body=doc, id=doc_id, parent=parent_id,
+                               refresh=(self.auto_commit_interval == 0))
+
         self.elastic.index(index=self.meta_index_name, doc_type=self.meta_type,
                            body=bson.json_util.dumps(metadata), id=doc_id,
                            refresh=(self.auto_commit_interval == 0))
@@ -249,9 +307,25 @@ class DocManager(DocManagerBase):
     def remove(self, document_id, namespace, timestamp):
         """Remove a document from Elasticsearch."""
         index, doc_type = self._index_and_mapping(namespace)
-        self.elastic.delete(index=index, doc_type=doc_type,
-                            id=u(document_id),
-                            refresh=(self.auto_commit_interval == 0))
+
+        if doc_type in self.routing and 'parentField' in self.routing[doc_type]:
+            # We can't use delete() directly here and have to do a full search first.
+            # This is due to the fact that Elasticsearch needs the parent ID to
+            # know where to route the delete request. We might not have the parent
+            # ID available in our remove request though.
+            document = self._search_doc_by_id(index, doc_type, document_id)
+            if document is None:
+                LOG.error('Could not find document with ID "%s" in Elasticsearch to apply remove', u(document_id))
+                return
+            parent_id = self._get_parent_id(doc_type, document)
+            self.elastic.delete(index=index, doc_type=doc_type,
+                                id=u(document_id), parent=parent_id,
+                                refresh=(self.auto_commit_interval == 0))
+        else:
+            self.elastic.delete(index=index, doc_type=doc_type,
+                                id=u(document_id),
+                                refresh=(self.auto_commit_interval == 0))
+
         self.elastic.delete(index=self.meta_index_name, doc_type=self.meta_type,
                             id=u(document_id),
                             refresh=(self.auto_commit_interval == 0))

--- a/mongo_connector/doc_managers/elastic2_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic2_doc_manager.py
@@ -80,7 +80,7 @@ class DocManager(DocManagerBase):
         """Get parent ID from doc"""
         if doc_type in self.routing:
             if '_parent' in doc:
-                return doc['_parent']
+                return doc.pop('_parent')
 
             parent_field = self.routing[doc_type].get('parentField')
             if not parent_field:
@@ -178,6 +178,8 @@ class DocManager(DocManagerBase):
         updated = self.apply_update(document['_source'], update_spec)
         # _id is immutable in MongoDB, so won't have changed in update
         updated['_id'] = document['_id']
+        if '_parent' in document:
+            updated['_parent'] = document['_parent']
         self.upsert(updated, namespace, timestamp)
         # upsert() strips metadata, so only _id + fields in _source still here
         return updated
@@ -341,6 +343,8 @@ class DocManager(DocManagerBase):
         for hit in scan(self.elastic, query=kwargs.pop('body', None),
                         scroll='10m', **kwargs):
             hit['_source']['_id'] = hit['_id']
+            if '_parent' in hit:
+                hit['_source']['_parent'] = hit['_parent']
             yield hit['_source']
 
     def search(self, start_ts, end_ts):

--- a/mongo_connector/doc_managers/elastic2_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic2_doc_manager.py
@@ -82,7 +82,7 @@ class DocManager(DocManagerBase):
             parent_field = self.routing[doc_type].get('parentField')
             if not parent_field:
                 return None
-            parent_id = doc.get(parent_field)
+            parent_id = doc.pop(parent_field) if parent_field in doc else None
             return self._formatter.transform_value(parent_id)
 
     def _search_doc_by_id(self, index, doc_type, doc_id):
@@ -235,6 +235,7 @@ class DocManager(DocManagerBase):
                 parent_id = self._get_parent_id(doc_type, doc)
                 if parent_id is not None:
                     document_action["_parent"] = parent_id
+                    document_action["_source"] = self._formatter.format_document(doc)
 
                 yield document_action
                 yield document_meta

--- a/mongo_connector/doc_managers/elastic2_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic2_doc_manager.py
@@ -79,9 +79,13 @@ class DocManager(DocManagerBase):
     def _get_parent_id(self, doc_type, doc):
         """Get parent ID from doc"""
         if doc_type in self.routing:
+            if '_parent' in doc:
+                return doc['_parent']
+
             parent_field = self.routing[doc_type].get('parentField')
             if not parent_field:
                 return None
+
             parent_id = doc.pop(parent_field) if parent_field in doc else None
             return self._formatter.transform_value(parent_id)
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ except IOError:
     long_description = None  # Install without README.rst
 
 setup(name='elastic2-doc-manager',
-      version='0.1.0',
+      version='0.2.0',
       maintainer='mongodb',
       description='Elastic2 plugin for mongo-connector',
       long_description=long_description,

--- a/tests/test_elastic2_doc_manager.py
+++ b/tests/test_elastic2_doc_manager.py
@@ -26,6 +26,7 @@ from mongo_connector.test_utils import MockGridFSFile, TESTARGS
 from tests import unittest, elastic_pair
 from tests.test_elastic2 import ElasticsearchTestCase
 
+
 class TestElasticDocManager(ElasticsearchTestCase):
     """Unit tests for the Elastic DocManager."""
 
@@ -47,6 +48,24 @@ class TestElasticDocManager(ElasticsearchTestCase):
         doc = self.elastic_doc.update(doc_id, update_spec, *TESTARGS)
         self.assertEqual(doc, {"_id": '1', "c": 3})
 
+    def test_update_child_doc(self):
+        """Test update child document."""
+        doc_id = 1
+        doc = {"_id": doc_id, "a": 1, "b": 2, "parent_id": 3}
+        self.elastic_doc.upsert(doc, *self.PARENT_CHILD_TEST_ARGS)
+        # $set only
+        update_spec = {"$set": {"a": 1, "b": 2}}
+        doc = self.elastic_doc.update(doc_id, update_spec, *self.PARENT_CHILD_TEST_ARGS)
+        self.assertEqual(doc, {"_id": '1', "a": 1, "b": 2})
+        # $unset only
+        update_spec = {"$unset": {"a": True}}
+        doc = self.elastic_doc.update(doc_id, update_spec, *self.PARENT_CHILD_TEST_ARGS)
+        self.assertEqual(doc, {"_id": '1', "b": 2})
+        # mixed $set/$unset
+        update_spec = {"$unset": {"b": True}, "$set": {"c": 3}}
+        doc = self.elastic_doc.update(doc_id, update_spec, *self.PARENT_CHILD_TEST_ARGS)
+        self.assertEqual(doc, {"_id": '1', "c": 3})
+
     def test_upsert(self):
         """Test the upsert method."""
         docc = {'_id': '1', 'name': 'John'}
@@ -58,6 +77,16 @@ class TestElasticDocManager(ElasticsearchTestCase):
         for doc in res:
             self.assertEqual(doc['_id'], '1')
             self.assertEqual(doc['_source']['name'], 'John')
+
+    def test_upsert_with_parent_id(self):
+        """Test the upsert method with parent_id provided."""
+        docc = {'_id': '1', 'name': 'John', 'parent_id': '2'}
+        self.elastic_doc.upsert(docc, *self.PARENT_CHILD_TEST_ARGS)
+        for doc in self._search(doc_type=self.PARENT_CHILD_TEST_TYPE):
+            self.assertEqual(doc['_id'], '1')
+            self.assertEqual(doc['name'], 'John')
+            self.assertEqual(doc['_parent'], '2')
+            self.assertNotIn('parent_id', doc)
 
     def test_bulk_upsert(self):
         """Test the bulk_upsert method."""
@@ -81,6 +110,22 @@ class TestElasticDocManager(ElasticsearchTestCase):
         for i, r in enumerate(returned_ids):
             self.assertEqual(r, 2*i)
 
+    def test_bulk_upsert_with_parent_id(self):
+        """Test the bulk_upsert method with parent_id provided."""
+        self.elastic_doc.bulk_upsert([], *TESTARGS)
+
+        docs = ({"_id": i, "parent_id": i * 2} for i in range(1000))
+        self.elastic_doc.bulk_upsert(docs, *self.PARENT_CHILD_TEST_ARGS)
+        self.elastic_doc.commit()
+        returned_docs = sorted([(int(doc["_id"]), int(doc["_parent"]))
+                                for doc in self._search(doc_type=self.PARENT_CHILD_TEST_TYPE)],
+                               key=lambda x: x[0])
+        self.assertEqual(self._count(), 1000)
+        self.assertEqual(len(returned_docs), 1000)
+        for i, r in enumerate(returned_docs):
+            self.assertEqual(r[0], i)
+            self.assertEqual(r[1], i * 2)
+
     def test_remove(self):
         """Test the remove method."""
         docc = {'_id': '1', 'name': 'John'}
@@ -98,6 +143,17 @@ class TestElasticDocManager(ElasticsearchTestCase):
             body={"query": {"match_all": {}}}
         )["hits"]["hits"]
         res = [x["_source"] for x in res]
+        self.assertEqual(len(res), 0)
+
+    def test_remove_child_doc(self):
+        """Test remove child document."""
+        docc = {'_id': '1', 'name': 'John', 'parent_id': '2'}
+        self.elastic_doc.upsert(docc, *self.PARENT_CHILD_TEST_ARGS)
+        res = [doc for doc in self._search(doc_type=self.PARENT_CHILD_TEST_TYPE)]
+        self.assertEqual(len(res), 1)
+
+        self.elastic_doc.remove(docc['_id'], *self.PARENT_CHILD_TEST_ARGS)
+        res = [doc for doc in self._search(doc_type=self.PARENT_CHILD_TEST_TYPE)]
         self.assertEqual(len(res), 0)
 
     def test_insert_file(self):


### PR DESCRIPTION
Almost port from https://github.com/mongodb-labs/mongo-connector/pull/308 and add some tests, you should set `parentField` option in your mongo-connector configuration file, the value of `parentField` will become the parent ID.

For example:

``` json
{
  "docManagers": [
    {
      "docManager": "elastic2_doc_manager",
      "targetURL": "localhost:9200",
      "args": {
        "routing": {
          "SOME_DOC_TYPE": {
            "parentField": "SOME_FIELD_NAME"
          }
        }
      }
    }
  ]
}
```
