### PR TITLE
Map BulkIndexError to OperationFailed

### DIFF
--- a/mongo_connector/doc_managers/elastic2_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic2_doc_manager.py
@@ -26,7 +26,7 @@ from threading import Timer
 import bson.json_util
 
 from elasticsearch import Elasticsearch, exceptions as es_exceptions, connection as es_connection
-from elasticsearch.helpers import bulk, scan, streaming_bulk
+from elasticsearch.helpers import bulk, scan, streaming_bulk, BulkIndexError
 
 from mongo_connector import errors
 from mongo_connector.compat import u
@@ -44,6 +44,7 @@ except ImportError:
     _HAS_AWS = False
 
 wrap_exceptions = exception_wrapper({
+    BulkIndexError: errors.OperationFailed,
     es_exceptions.ConnectionError: errors.ConnectionFailed,
     es_exceptions.TransportError: errors.OperationFailed,
     es_exceptions.NotFoundError: errors.OperationFailed,


### PR DESCRIPTION
The OplogThread will log BulkIndexErrors instead of aborting.

Fixes #6