### PR TITLE
#456 Elasticsearch doc manager should accept multiple hosts

### DIFF
--- a/mongo_connector/doc_managers/elastic2_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic2_doc_manager.py
@@ -66,6 +66,9 @@ class DocManager(DocManagerBase):
                  attachment_field="content", **kwargs):
         aws = kwargs.get('aws', {'access_id': '', 'secret_key': '', 'region': 'us-east-1'})
         client_options = kwargs.get('clientOptions', {})
+        client_options.setdefault('sniff_on_start', True)
+        client_options.setdefault('sniff_on_connection_fail', True)
+        client_options.setdefault('sniffer_timeout', 60)
         if 'aws' in kwargs:
             if _HAS_AWS is False:
                 raise ConfigurationError('aws extras must be installed to sign Elasticsearch requests')
@@ -82,8 +85,10 @@ class DocManager(DocManagerBase):
             client_options['use_ssl'] = True
             client_options['verify_certs'] = True
             client_options['connection_class'] = es_connection.RequestsHttpConnection
+        if type(url) is not list:
+            url = [url]
         self.elastic = Elasticsearch(
-            hosts=[url], **client_options)
+            hosts=url, **client_options)
         self.auto_commit_interval = auto_commit_interval
         self.meta_index_name = meta_index_name
         self.meta_type = meta_type

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,3 +28,5 @@ else:
 elastic_host = unicode(os.environ.get("ES_HOST", 'localhost'))
 elastic_port = unicode(os.environ.get("ES_PORT", 9200))
 elastic_pair = '%s:%s' % (elastic_host, elastic_port)
+elastic_nodes = [ elastic_pair, '%s:%s' % (elastic_host, unicode(int(elastic_port)+1))]
+

--- a/tests/test_elastic2.py
+++ b/tests/test_elastic2.py
@@ -32,7 +32,7 @@ from mongo_connector.test_utils import (ReplicaSet,
                                         close_client)
 
 from mongo_connector.util import retry_until_ok
-from tests import unittest, elastic_pair
+from tests import unittest, elastic_pair, elastic_nodes
 
 
 class ElasticsearchTestCase(unittest.TestCase):
@@ -276,6 +276,14 @@ class TestElastic(ElasticsearchTestCase):
             self.assertNotIn('inf', doc)
             self.assertNotIn('nan', doc)
             self.assertTrue(doc['still_exists'])
+
+class TestElasticMultipleHosts(unittest.TestCase):
+    """Integration tests for mongo-connector + Elasticsearch Cluster."""
+
+    def test_multiple_hosts(self):
+        elastic_doc =  DocManager(elastic_nodes)
+        self.assertEqual(len(elastic_doc.elastic.transport.hosts), 2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added support for multiple Elastic hosts to be supplied. Thus, ensuring HA of mongo-connector with regards to Elastic clusters