### PR TITLE
Fix for travis configuration: upgrade setuptools to be able to install urllib3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.5
 
 install:
+  - pip install --upgrade setuptools
   - pip install mongo-orchestration
   - sudo curl -L -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.2.0/elasticsearch-2.2.0.tar.gz
   - tar -xvf elasticsearch-2.2.0.tar.gz


### PR DESCRIPTION
There is a problem with travis configuration... described and commented inside below pull request:
[Handle <= as an environment marker](https://github.com/django-haystack/django-haystack/pull/1444)

Same problem happen for elasti2_doc_manager travis configuration.
