### PR TITLE
Replace deprecated/removed filtered query with bool

### DIFF
--- a/mongo_connector/doc_managers/elastic2_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic2_doc_manager.py
@@ -323,12 +323,8 @@ class DocManager(DocManagerBase):
             index=self.meta_index_name,
             body={
                 "query": {
-                    "bool": {
-                        "filter": {
-                            "range": {
-                                "_ts": {"gte": start_ts, "lte": end_ts}
-                            }
-                        }
+                    "range": {
+                        "_ts": {"gte": start_ts, "lte": end_ts}
                     }
                 }
             })

--- a/mongo_connector/doc_managers/elastic2_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic2_doc_manager.py
@@ -323,7 +323,7 @@ class DocManager(DocManagerBase):
             index=self.meta_index_name,
             body={
                 "query": {
-                    "filtered": {
+                    "bool": {
                         "filter": {
                             "range": {
                                 "_ts": {"gte": start_ts, "lte": end_ts}


### PR DESCRIPTION
This is required to use the elastic2-doc-manager with Elasticsearch 5.0.0. The `filtered` query has been deprecated since 2.0.0 and was removed in 5.0.0: https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filtered-query.html.