### PR TITLE
Support parent-child relationship

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.egg-info/
 *~
 .DS_Store
 /test/data

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ python:
 install:
   - pip install --upgrade setuptools
   - pip install mongo-orchestration
-  - sudo curl -L -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.1/elasticsearch-2.3.1.tar.gz
-  - tar -xvf elasticsearch-2.3.1.tar.gz
-  - cd elasticsearch-2.3.1
+  - sudo curl -L -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.1/elasticsearch-2.4.1.tar.gz
+  - tar -xvf elasticsearch-2.4.1.tar.gz
+  - cd elasticsearch-2.4.1
   - echo 'y' |  bin/plugin install mapper-attachments
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ python:
 install:
   - pip install --upgrade setuptools
   - pip install mongo-orchestration
-  - sudo curl -L -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.2.0/elasticsearch-2.2.0.tar.gz
-  - tar -xvf elasticsearch-2.2.0.tar.gz
-  - cd elasticsearch-2.2.0
+  - sudo curl -L -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.1/elasticsearch-2.3.1.tar.gz
+  - tar -xvf elasticsearch-2.3.1.tar.gz
+  - cd elasticsearch-2.3.1
   - echo 'y' |  bin/plugin install mapper-attachments
 
 before_script:

--- a/README.rst
+++ b/README.rst
@@ -32,9 +32,9 @@ Running the tests
 Requirements
 ~~~~~~~~~~~~
 
-1. Copy of the Elastic 2.x Document Manager Github repository
+1. Copy of the Elastic 2.x Document Manager GitHub repository
 
-  The tests are not included in the package from PyPI and can only be acquired by cloning this repository on Github::
+  The tests are not included in the package from PyPI and can only be acquired by cloning this repository on GitHub::
 
       git clone https://github.com/mongodb-labs/elastic2-doc-manager
 

--- a/mongo_connector/doc_managers/elastic2_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic2_doc_manager.py
@@ -117,6 +117,7 @@ class DocManager(DocManagerBase):
         self.meta_type = meta_type
         self.unique_key = unique_key
         self.chunk_size = chunk_size
+        self.routing = kwargs.get('routing', {})
         if self.auto_commit_interval not in [None, 0]:
             self.run_auto_commit()
         self._formatter = DefaultDocumentFormatter()
@@ -128,6 +129,35 @@ class DocManager(DocManagerBase):
         """Helper method for getting the index and type from a namespace."""
         index, doc_type = namespace.split('.', 1)
         return index.lower(), doc_type
+
+    def _get_parent_id(self, doc_type, doc):
+        """Get parent ID from doc"""
+        if doc_type in self.routing:
+            if '_parent' in doc:
+                return doc.pop('_parent')
+
+            parent_field = self.routing[doc_type].get('parentField')
+            if not parent_field:
+                return None
+
+            parent_id = doc.pop(parent_field) if parent_field in doc else None
+            return self._formatter.transform_value(parent_id)
+
+    def _search_doc_by_id(self, index, doc_type, doc_id):
+        """Search document in Elasticsearch by _id"""
+        result = self.elastic.search(index=index, doc_type=doc_type,
+                                     body={
+                                         'query': {
+                                             'ids': {
+                                                 'type': doc_type,
+                                                 'values': [u(doc_id)]
+                                             }
+                                         }
+                                     })
+        if result['hits']['total'] == 1:
+            return result['hits']['hits'][0]
+        else:
+            return None
 
     def stop(self):
         """Stop the auto-commit thread."""
@@ -185,11 +215,25 @@ class DocManager(DocManagerBase):
         """
         self.commit()
         index, doc_type = self._index_and_mapping(namespace)
-        document = self.elastic.get(index=index, doc_type=doc_type,
-                                    id=u(document_id))
+
+        if doc_type in self.routing and 'parentField' in self.routing[doc_type]:
+            # We can't use get() here and have to do a full search instead.
+            # This is due to the fact that Elasticsearch needs the parent ID to
+            # know where to route the get request. We might not have the parent
+            # ID available in our update request though.
+            document = self._search_doc_by_id(index, doc_type, document_id)
+            if document is None:
+                LOG.error('Could not find document with ID "%s" in Elasticsearch to apply update', u(document_id))
+                return None
+        else:
+            document = self.elastic.get(index=index, doc_type=doc_type,
+                                        id=u(document_id))
+
         updated = self.apply_update(document['_source'], update_spec)
         # _id is immutable in MongoDB, so won't have changed in update
         updated['_id'] = document['_id']
+        if '_parent' in document:
+            updated['_parent'] = document['_parent']
         self.upsert(updated, namespace, timestamp)
         # upsert() strips metadata, so only _id + fields in _source still here
         return updated
@@ -204,10 +248,18 @@ class DocManager(DocManagerBase):
             "ns": namespace,
             "_ts": timestamp
         }
+
+        parent_id = self._get_parent_id(doc_type, doc)
         # Index the source document, using lowercase namespace as index name.
-        self.elastic.index(index=index, doc_type=doc_type,
-                           body=self._formatter.format_document(doc), id=doc_id,
-                           refresh=(self.auto_commit_interval == 0))
+        if parent_id is None:
+            self.elastic.index(index=index, doc_type=doc_type,
+                               body=self._formatter.format_document(doc), id=doc_id,
+                               refresh=(self.auto_commit_interval == 0))
+        else:
+            self.elastic.index(index=index, doc_type=doc_type,
+                               body=self._formatter.format_document(doc), id=doc_id,
+                               parent=parent_id, refresh=(self.auto_commit_interval == 0))
+
         # Index document metadata with original namespace (mixed upper/lower).
         self.elastic.index(index=self.meta_index_name, doc_type=self.meta_type,
                            body=bson.json_util.dumps(metadata), id=doc_id,
@@ -239,6 +291,12 @@ class DocManager(DocManagerBase):
                         "_ts": timestamp
                     }
                 }
+
+                parent_id = self._get_parent_id(doc_type, doc)
+                if parent_id is not None:
+                    document_action["_parent"] = parent_id
+                    document_action["_source"] = self._formatter.format_document(doc)
+
                 yield document_action
                 yield document_meta
             if doc is None:
@@ -292,9 +350,16 @@ class DocManager(DocManagerBase):
         doc = self._formatter.format_document(doc)
         doc[self.attachment_field] = base64.b64encode(f.read()).decode()
 
-        self.elastic.index(index=index, doc_type=doc_type,
-                           body=doc, id=doc_id,
-                           refresh=(self.auto_commit_interval == 0))
+        parent_id = self._get_parent_id(doc_type, doc)
+        if parent_id is None:
+            self.elastic.index(index=index, doc_type=doc_type,
+                               body=doc, id=doc_id,
+                               refresh=(self.auto_commit_interval == 0))
+        else:
+            self.elastic.index(index=index, doc_type=doc_type,
+                               body=doc, id=doc_id, parent=parent_id,
+                               refresh=(self.auto_commit_interval == 0))
+
         self.elastic.index(index=self.meta_index_name, doc_type=self.meta_type,
                            body=bson.json_util.dumps(metadata), id=doc_id,
                            refresh=(self.auto_commit_interval == 0))
@@ -303,9 +368,25 @@ class DocManager(DocManagerBase):
     def remove(self, document_id, namespace, timestamp):
         """Remove a document from Elasticsearch."""
         index, doc_type = self._index_and_mapping(namespace)
-        self.elastic.delete(index=index, doc_type=doc_type,
-                            id=u(document_id),
-                            refresh=(self.auto_commit_interval == 0))
+
+        if doc_type in self.routing and 'parentField' in self.routing[doc_type]:
+            # We can't use delete() directly here and have to do a full search first.
+            # This is due to the fact that Elasticsearch needs the parent ID to
+            # know where to route the delete request. We might not have the parent
+            # ID available in our remove request though.
+            document = self._search_doc_by_id(index, doc_type, document_id)
+            if document is None:
+                LOG.error('Could not find document with ID "%s" in Elasticsearch to apply remove', u(document_id))
+                return
+            parent_id = self._get_parent_id(doc_type, document)
+            self.elastic.delete(index=index, doc_type=doc_type,
+                                id=u(document_id), parent=parent_id,
+                                refresh=(self.auto_commit_interval == 0))
+        else:
+            self.elastic.delete(index=index, doc_type=doc_type,
+                                id=u(document_id),
+                                refresh=(self.auto_commit_interval == 0))
+
         self.elastic.delete(index=self.meta_index_name, doc_type=self.meta_type,
                             id=u(document_id),
                             refresh=(self.auto_commit_interval == 0))
@@ -316,6 +397,8 @@ class DocManager(DocManagerBase):
         for hit in scan(self.elastic, query=kwargs.pop('body', None),
                         scroll='10m', **kwargs):
             hit['_source']['_id'] = hit['_id']
+            if '_parent' in hit:
+                hit['_source']['_parent'] = hit['_parent']
             yield hit['_source']
 
     def search(self, start_ts, end_ts):

--- a/tests/test_elastic2.py
+++ b/tests/test_elastic2.py
@@ -46,8 +46,8 @@ class ElasticsearchTestCase(unittest.TestCase):
     def setUpClass(cls):
         cls.elastic_conn = Elasticsearch(hosts=[elastic_pair])
         cls.elastic_doc = DocManager(
-            elastic_pair, auto_commit_interval=0, routing={
-                cls.PARENT_CHILD_TEST_TYPE: {"parentField": "parent_id"}})
+            elastic_pair, auto_commit_interval=0, routing={'test': {
+                cls.PARENT_CHILD_TEST_TYPE: {"parentField": "parent_id"}}})
 
     def setUp(self):
         # Create target index in elasticsearch
@@ -65,6 +65,8 @@ class ElasticsearchTestCase(unittest.TestCase):
 
     def tearDown(self):
         self.elastic_conn.indices.delete(index='test', ignore=404)
+        self.elastic_conn.indices.delete(
+            index=self.elastic_doc.meta_index_name, ignore=404)
 
     def _search(self, query=None, doc_type="test"):
         query = query or {"match_all": {}}

--- a/tests/test_elastic2.py
+++ b/tests/test_elastic2.py
@@ -45,9 +45,9 @@ class ElasticsearchTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.elastic_conn = Elasticsearch(hosts=[elastic_pair])
-        cls.elastic_doc = DocManager(elastic_pair,
-                                     auto_commit_interval=0,
-                                     routing={cls.PARENT_CHILD_TEST_TYPE: {"parentField": "parent_id"}})
+        cls.elastic_doc = DocManager(
+            elastic_pair, auto_commit_interval=0, routing={
+                cls.PARENT_CHILD_TEST_TYPE: {"parentField": "parent_id"}})
 
     def setUp(self):
         # Create target index in elasticsearch

--- a/tests/test_elastic2.py
+++ b/tests/test_elastic2.py
@@ -28,6 +28,7 @@ sys.path[0:0] = [""]
 from mongo_connector.connector import Connector
 from mongo_connector.doc_managers.elastic2_doc_manager import DocManager
 from mongo_connector.test_utils import (ReplicaSet,
+                                        TESTARGS,
                                         assert_soon,
                                         close_client)
 
@@ -38,25 +39,37 @@ from tests import unittest, elastic_pair, elastic_nodes
 class ElasticsearchTestCase(unittest.TestCase):
     """Base class for all ES TestCases."""
 
+    PARENT_CHILD_TEST_TYPE = "parent_child_test"
+    PARENT_CHILD_TEST_ARGS = ("test." + PARENT_CHILD_TEST_TYPE, 1)
+
     @classmethod
     def setUpClass(cls):
         cls.elastic_conn = Elasticsearch(hosts=[elastic_pair])
         cls.elastic_doc = DocManager(elastic_pair,
-                                     auto_commit_interval=0)
+                                     auto_commit_interval=0,
+                                     routing={cls.PARENT_CHILD_TEST_TYPE: {"parentField": "parent_id"}})
 
     def setUp(self):
         # Create target index in elasticsearch
-        self.elastic_conn.indices.create(index='test', ignore=400)
+        self.elastic_conn.indices.create(index='test', ignore=400, body={
+            "mappings": {
+                self.PARENT_CHILD_TEST_TYPE: {
+                    "_parent": {
+                        "type": "test"
+                    }
+                }
+            }
+        })
         self.elastic_conn.cluster.health(wait_for_status='yellow',
                                          index='test')
 
     def tearDown(self):
         self.elastic_conn.indices.delete(index='test', ignore=404)
 
-    def _search(self, query=None):
+    def _search(self, query=None, doc_type="test"):
         query = query or {"match_all": {}}
         return self.elastic_doc._stream_search(
-            index="test", doc_type='test',
+            index="test", doc_type=doc_type,
             body={"query": query}
         )
 

--- a/tests/test_elastic2.py
+++ b/tests/test_elastic2.py
@@ -50,6 +50,8 @@ class ElasticsearchTestCase(unittest.TestCase):
                 cls.PARENT_CHILD_TEST_TYPE: {"parentField": "parent_id"}}})
 
     def setUp(self):
+        # Create meta index
+        self.elastic_conn.indices.create(index='mongodb_meta', ignore=400)
         # Create target index in elasticsearch
         self.elastic_conn.indices.create(index='test', ignore=400, body={
             "mappings": {

--- a/tests/test_elastic2_doc_manager.py
+++ b/tests/test_elastic2_doc_manager.py
@@ -50,6 +50,24 @@ class TestElasticDocManager(ElasticsearchTestCase):
         doc = self.elastic_doc.update(doc_id, update_spec, *TESTARGS)
         self.assertEqual(doc, {"_id": '1', "c": 3})
 
+    def test_update_child_doc(self):
+        """Test update child document."""
+        doc_id = 1
+        doc = {"_id": doc_id, "a": 1, "b": 2, "parent_id": 3}
+        self.elastic_doc.upsert(doc, *self.PARENT_CHILD_TEST_ARGS)
+        # $set only
+        update_spec = {"$set": {"a": 1, "b": 2}}
+        doc = self.elastic_doc.update(doc_id, update_spec, *self.PARENT_CHILD_TEST_ARGS)
+        self.assertEqual(doc, {"_id": '1', "a": 1, "b": 2})
+        # $unset only
+        update_spec = {"$unset": {"a": True}}
+        doc = self.elastic_doc.update(doc_id, update_spec, *self.PARENT_CHILD_TEST_ARGS)
+        self.assertEqual(doc, {"_id": '1', "b": 2})
+        # mixed $set/$unset
+        update_spec = {"$unset": {"b": True}, "$set": {"c": 3}}
+        doc = self.elastic_doc.update(doc_id, update_spec, *self.PARENT_CHILD_TEST_ARGS)
+        self.assertEqual(doc, {"_id": '1', "c": 3})
+
     def test_upsert(self):
         """Test the upsert method."""
         docc = {'_id': '1', 'name': 'John'}
@@ -61,6 +79,16 @@ class TestElasticDocManager(ElasticsearchTestCase):
         for doc in res:
             self.assertEqual(doc['_id'], '1')
             self.assertEqual(doc['_source']['name'], 'John')
+
+    def test_upsert_with_parent_id(self):
+        """Test the upsert method with parent_id provided."""
+        docc = {'_id': '1', 'name': 'John', 'parent_id': '2'}
+        self.elastic_doc.upsert(docc, *self.PARENT_CHILD_TEST_ARGS)
+        for doc in self._search(doc_type=self.PARENT_CHILD_TEST_TYPE):
+            self.assertEqual(doc['_id'], '1')
+            self.assertEqual(doc['name'], 'John')
+            self.assertEqual(doc['_parent'], '2')
+            self.assertNotIn('parent_id', doc)
 
     def test_bulk_upsert(self):
         """Test the bulk_upsert method."""
@@ -84,6 +112,22 @@ class TestElasticDocManager(ElasticsearchTestCase):
         for i, r in enumerate(returned_ids):
             self.assertEqual(r, 2*i)
 
+    def test_bulk_upsert_with_parent_id(self):
+        """Test the bulk_upsert method with parent_id provided."""
+        self.elastic_doc.bulk_upsert([], *TESTARGS)
+
+        docs = ({"_id": i, "parent_id": i * 2} for i in range(1000))
+        self.elastic_doc.bulk_upsert(docs, *self.PARENT_CHILD_TEST_ARGS)
+        self.elastic_doc.commit()
+        returned_docs = sorted([(int(doc["_id"]), int(doc["_parent"]))
+                                for doc in self._search(doc_type=self.PARENT_CHILD_TEST_TYPE)],
+                               key=lambda x: x[0])
+        self.assertEqual(self._count(), 1000)
+        self.assertEqual(len(returned_docs), 1000)
+        for i, r in enumerate(returned_docs):
+            self.assertEqual(r[0], i)
+            self.assertEqual(r[1], i * 2)
+
     def test_remove(self):
         """Test the remove method."""
         docc = {'_id': '1', 'name': 'John'}
@@ -101,6 +145,17 @@ class TestElasticDocManager(ElasticsearchTestCase):
             body={"query": {"match_all": {}}}
         )["hits"]["hits"]
         res = [x["_source"] for x in res]
+        self.assertEqual(len(res), 0)
+
+    def test_remove_child_doc(self):
+        """Test remove child document."""
+        docc = {'_id': '1', 'name': 'John', 'parent_id': '2'}
+        self.elastic_doc.upsert(docc, *self.PARENT_CHILD_TEST_ARGS)
+        res = [doc for doc in self._search(doc_type=self.PARENT_CHILD_TEST_TYPE)]
+        self.assertEqual(len(res), 1)
+
+        self.elastic_doc.remove(docc['_id'], *self.PARENT_CHILD_TEST_ARGS)
+        res = [doc for doc in self._search(doc_type=self.PARENT_CHILD_TEST_TYPE)]
         self.assertEqual(len(res), 0)
 
     def test_insert_file(self):


### PR DESCRIPTION
This builds on @xiaogaozi's work on #3.

Add support for parent-child mapping.
 

### Example Usage
Let's use the data from the [Elasticsearch Parent-Child Mapping docs](https://www.elastic.co/guide/en/elasticsearch/guide/2.x/parent-child-mapping.html) and adapt it to MongoDB. Suppose you have a `company` database in MongoDB with the collections `branch` and `employees`. Use this script to load some sample data:
**Note**: this example assumes you have a MongoDB replica set on localhost:27017 and an Elasticsearch instance on localhost:9200.
```python
from pymongo import MongoClient

HOST = 'mongodb://localhost:27017'
client = MongoClient(HOST)

company = client.company
branch = company.branch
employee = company.employee


def insert_parent_child(parent_doc, child_doc, parent_field):
    res = branch.insert_one(parent_doc)
    child_doc[parent_field] = res.inserted_id
    employee.insert_one(child_doc)

branch_docs = [
    {'name': 'London Westminster', 'city': 'London', 'country': 'UK'},
    {'name': 'Liverpool Central', 'city': 'Liverpool', 'country': 'UK'},
    {'name': 'Champs Elysees', 'city': 'Paris', 'country': 'France'}]
employee_docs = [
    {'name': 'Mark Thomas', 'dob': '1982-05-16', 'hobby': 'diving'},
    {'name': 'Barry Smith', 'dob': '1979-04-01', 'hobby': 'hiking'},
    {'name': 'Adrien Grand', 'dob': '1987-05-11', 'hobby': 'horses'}]

for branch_doc, employee_doc in zip(branch_docs, employee_docs):
    insert_parent_child(branch_doc, employee_doc, 'branch_id')
```

In the current pull request, the elastic-doc-manager does not automatically create the parent-child mapping. So create the mapping manually before running mongo-connector:
```
curl -XPUT 'http://localhost:9200/company' -d '{
  "mappings": {
    "branch": {},
    "employee": {
      "_parent": {
        "type": "branch" 
      }
    }
  }
}'
```

Next, create the mongo-connector config file with parent-child mapping options:
```json
{
  "mainAddress": "localhost:27017",
  "verbosity": 2,
  "docManagers":[
    {
      "docManager": "elastic2_doc_manager",
      "targetURL": "localhost:9200",
      "args": {
        "routing": {
          "company": {
            "employee": {
              "parentField": "branch_id"
            }
          }
        }
      }
    }
  ]
}
```

Next, run mongo-connector with the above config file:
`mongo-connector -c parent-child-config.json`

Finally, you can query Elasticsearch with your MongoDB data.

Query Elasticsearch for children by their parents:
```
curl -XGET 'http://localhost:9200/company/employee/_search/?pretty=1' -d '{
  "query": {
    "has_parent": {
      "type": "branch",
      "query": {
        "match": {
          "country": "UK"
        }
      }
    }
  }
}'
```

Or, query Elasticsearch for parents by their children:
```
curl -XGET 'http://localhost:9200/company/branch/_search/?pretty=1' -d '{
  "query": {
    "has_child": {
      "type": "employee",
      "query": {
        "range": {
          "dob": {
            "gte": "1980-01-01"
          }
        }
      }
    }
  }
}'
```

### Up for discussion:
- Should the config file format be changed?
- Should the DocManager automatically create the parent and child index/mapping?
  - In this case, we need to add a `parentType` field to the config file as well as the `parentField`.
- This does not support nested parent fields, eg. `"parentField": "foo.bar.parent_id"` will not work.
- This does not support grandparents and grandchildren. The difficulty here is that to insert a grandchild document, we need the parent id (for `parent`) and the grandparent id (for `routing`). I propose we only support grandparent relationships when the grandchild documents contain a `parentField` and an additional `routingField`. This would avoid having to query the parent collection to find the parent's `_routing` to use for `routing` (what if the parent doesn't exist yet which may happen during the collection dump?). This would support great-grandchildren, great-great-grandchildren, etc. automatically. Extending the example above with the [Elasticsearch Grandparents example](https://www.elastic.co/guide/en/elasticsearch/guide/2.x/grandparents.html):
```json
{
  "mainAddress": "localhost:27017",
  "verbosity": 2,
  "docManagers":[
    {
      "docManager": "elastic2_doc_manager",
      "targetURL": "localhost:9200",
      "args": {
        "routing": {
          "company": {
            "branch": {
              "parentField": "country_id"
            },
            "employee": {
              "parentField": "branch_id",
              "routingField": "routing_id"
            }
          }
        }
      }
    }
  ]
}
```