### PR TITLE
Do not automatically add sniff_* options

### DIFF
--- a/mongo_connector/doc_managers/elastic2_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic2_doc_manager.py
@@ -95,9 +95,6 @@ class DocManager(DocManagerBase):
                  meta_index_name="mongodb_meta", meta_type="mongodb_meta",
                  attachment_field="content", **kwargs):
         client_options = kwargs.get('clientOptions', {})
-        client_options.setdefault('sniff_on_start', True)
-        client_options.setdefault('sniff_on_connection_fail', True)
-        client_options.setdefault('sniffer_timeout', 60)
         if 'aws' in kwargs:
             if not _HAS_AWS:
                 raise errors.InvalidConfiguration(


### PR DESCRIPTION
https://github.com/mongodb-labs/elastic2-doc-manager/pull/17 added turning on Elasticsearch's sniffing options by default. I think we should revert this change and let the user opt into sniffing via the config file rather than opting out.

You can set these options like so:
```json
{
"docManagers": [
      {
          "docManager": "elastic2_doc_manager",
          "targetURL": ["elastic.1:9200","elastic.2:9200"],
          "args": {
             "clientOptions": {
                "sniff_on_start": true,
                "sniff_on_connection_fail": true,
                "sniffer_timeout": 60
            }
          }
      }
   ]
}
```

Sniffing is broken in the current elasticsearch-py client due to https://github.com/elastic/elasticsearch-py/issues/477 and multiple issues have been opened about this change in behavior: https://github.com/mongodb-labs/elastic2-doc-manager/issues/26, https://github.com/mongodb-labs/mongo-connector/issues/587, https://github.com/mongodb-labs/mongo-connector/issues/577