### PR TITLE
Update mongo-connector and requests-aws-sign dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 import sys
 
 test_suite = "tests"
-tests_require = ["mongo-orchestration >= 0.2, < 0.4", "requests >= 2.5.1"]
+tests_require = ["mongo-orchestration>=0.6.7,<1.0", "requests>=2.5.1"]
 
 if sys.version_info[:2] == (2, 6):
     # Need unittest2 to run unittests in Python 2.6
@@ -32,7 +32,7 @@ setup(name='elastic2-doc-manager',
       url='https://github.com/mongodb-labs/elastic2-doc-manager',
       install_requires=['mongo-connector >= 2.3.0', "elasticsearch>=2.0.0,<3.0.0"],
       packages=["mongo_connector", "mongo_connector.doc_managers"],
-      extras_require={'aws': ['boto3 >= 1.4.0', 'requests-aws-sign >= 0.1.1']},
+      extras_require={'aws': ['boto3 >= 1.4.0', 'requests-aws-sign >= 0.1.2']},
       license="Apache License, Version 2.0",
       classifiers=[
           "Development Status :: 4 - Beta",


### PR DESCRIPTION
requests-aws-sign 1.1.2 fixes support for Python 3, see https://github.com/jmenga/requests-aws-sign/pull/1.

Bumping mongo-orchestration to what mongo-connector itself uses.