### PR TITLE
Support for elasticsearch pipeline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 0.4.0
+-------------
+
+- Support for Elasticsearch 5.x pipelines
+
 Version 0.3.0
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Please note that non-wildcard namespaces have priority over the wildcard namespa
 **Configuration example**::
 
   {
-    "docManager": "elastic2-doc-manager",
+    "docManager": "elastic2_doc_manager",
     "targetURL": "localhost:9200",
     "bulkSize": 1000,
     "uniqueKey": "_id",

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,29 @@ dependencies along with the version of Elasticsearch::
 
   pip install 'elastic2-doc-manager[elastic2,aws]'
 
+Elasticsearch 5.x Pipelines
+---------------------------
+
+You can use elasticsearch `pipelines <https://www.elastic.co/guide/en/elasticsearch/reference/5.0/ingest.html>`__ by adding an extra configuration inside elastic2-doc-manager.
+
+This configuration will include the elasticseach namespace and it's pipeline. The namespaces can include wildcards.
+
+Please note that non-wildcard namespaces have priority over the wildcard namespaces.
+
+**Configuration example**::
+
+  {
+    "docManager": "elastic2-doc-manager",
+    "targetURL": "localhost:9200",
+    "bulkSize": 1000,
+    "uniqueKey": "_id",
+    "args": {
+      "pipelines": {
+        "app.user": "custom-pipeline-1",
+        "app.*": "custom-pipeline-2"
+      }
+    }
+  }
 
 Development
 -----------

--- a/mongo_connector/doc_managers/elastic2_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic2_doc_manager.py
@@ -514,6 +514,12 @@ class DocManager(DocManagerBase):
                 }
             })
 
+    def add_actions(self, actions):
+        """ Add custom actions directly to the action_buffer
+        """
+        with self.lock:
+            self.BulkBuffer.action_buffer.extend(actions)
+
     def index(self, action, meta_action, doc_source=None, update_spec=None):
         with self.lock:
             self.BulkBuffer.add_upsert(action, meta_action, doc_source, update_spec)

--- a/mongo_connector/doc_managers/elastic2_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic2_doc_manager.py
@@ -70,7 +70,7 @@ DEFAULT_SEND_INTERVAL = 5
 
 DEFAULT_AWS_REGION = 'us-east-1'
 
-__version__ = '0.3.0'
+__version__ = '0.4.0'
 """Elasticsearch 2.X DocManager version."""
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ except IOError:
 
 
 setup(name='elastic2-doc-manager',
-      version='0.4.0',
+      version='0.5.0',
       maintainer='mongodb',
       description='Elastic2 plugin for mongo-connector',
       long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ except IOError:
 
 
 setup(name='elastic2-doc-manager',
-      version='0.3.0',
+      version='0.4.0',
       maintainer='mongodb',
       description='Elastic2 plugin for mongo-connector',
       long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(name='elastic2-doc-manager',
       extras_require={
           'aws': ['boto3 >= 1.4.0', 'requests-aws-sign >= 0.1.2'],
           'elastic2': ['elasticsearch>=2.0.0,<3.0.0'],
-          'elastic5': ['elasticsearch>=5.0.0,<6.0.0']
+          'elastic5': ['elasticsearch>=5.4.0,<6.0.0']
       },
       packages=["mongo_connector", "mongo_connector.doc_managers"],
       license="Apache License, Version 2.0",


### PR DESCRIPTION
This pull request is to add support for elasticsearch [pipelines](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/ingest.html).

Associated issues

- #53  
- [add a pipeline for elasticsearch #731](https://github.com/mongodb-labs/mongo-connector/issues/731)
- [Ingest node #607](https://github.com/mongodb-labs/mongo-connector/issues/607)

**Implementation**

In this build there is a new class named **PipelineConfig**. This class will validate if each pipeline configured exists and expose a method to get the corresponding pipeline to the given namespace using [fnmatch](https://docs.python.org/2/library/fnmatch.html).

To improve the performance of the PipelineConfig.get_pipeline method, I've added a simple cache to keep the corresponding pipelines of each namespace.

**Set elasticsearch dependency from 5.0.0 to 5.4.0**

setup.py:
```
extras_require={
  ....
  'elastic5': ['elasticsearch>=5.4.0,<6.0.0']
},
```

Since elastic2_doc_manager is using the helper functions of elasticsearch, the only way to guarantee the pipeline feature, without extra validation or refactoring, is to force the elasticsearch driver version to be above or equal to 5.4.0.

If the driver is bellow 5.4.0 the pipeline property in the document action will be ignored.

[elasticsearch 5.4.0 changelog](https://elasticsearch-py.readthedocs.io/en/master/Changelog.html#id2)

**Configuration example**
```
{
  "docManager": "elastic2_doc_manager",
  "targetURL": "localhost:9200",
  "bulkSize": 1000,
  "uniqueKey": "_id",
  "args": {
    "pipelines": {
      "app.user": "custom-pipeline-1",
      "app.*": "custom-pipeline-2"
    }
  }
}
```