### PR TITLE
Fixing KeyError edge case on `doc.pop("_id")`

### DIFF
--- a/mongo_connector/doc_managers/elastic2_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic2_doc_manager.py
@@ -297,7 +297,7 @@ class DocManager(DocManagerBase):
         """Insert a document into Elasticsearch."""
         index, doc_type = self._index_and_mapping(namespace)
         # No need to duplicate '_id' in source document
-        doc_id = u(doc.pop("_id"))
+        doc_id = u(doc.get("_id")) if doc.has_key("_id") else u(doc.get("ui"))
         metadata = {
             'ns': namespace,
             '_ts': timestamp
@@ -321,9 +321,6 @@ class DocManager(DocManagerBase):
         }
 
         self.index(action, meta_action, doc, update_spec)
-
-        # Leave _id, since it's part of the original document
-        doc['_id'] = doc_id
 
     @wrap_exceptions
     def bulk_upsert(self, docs, namespace, timestamp):


### PR DESCRIPTION
Related to the following issue: https://github.com/mongodb-labs/elastic2-doc-manager/issues/58
If someone can look in to why this works (or if it's a totally useless change for most people), that'd be helpful.